### PR TITLE
Fix the issue with activating Arm home and arm away.

### DIFF
--- a/keypad_blueprint.yaml
+++ b/keypad_blueprint.yaml
@@ -114,6 +114,8 @@ action:
       sequence:
         - service: alarm_control_panel.alarm_arm_away
           entity_id: !input alarm
+          data:
+            code: "{{ trigger.event.data.event_data }}"
     - conditions:
         - condition: and
           conditions:
@@ -125,6 +127,8 @@ action:
       sequence:
         - service: alarm_control_panel.alarm_arm_home
           entity_id: !input alarm
+          data:
+            code: "{{ trigger.event.data.event_data }}"
     - conditions:
         - condition: trigger
           id: invalid_code


### PR DESCRIPTION
There was missing required lines that will provide pincode data for activating alarm to Home Assistant. That line was only on Disarm so you couldn't activate alarm with pincode on the keypad.
This has fixed on my end. (Verified with alarmo integration)