### PR TITLE
✨ Update Volume Levels Based on Alarm Mode and Refactor Keypad Automation

### DIFF
--- a/keypad_blueprint.yaml
+++ b/keypad_blueprint.yaml
@@ -35,8 +35,30 @@ blueprint:
       default: []
       selector:
         action:
+    volume_normal:
+      name: Volume
+      description: Volume level for announcements on the keypad
+      default: 7
+      selector:
+        number:
+          min: 0
+          max: 10
+          step: 1
+          unit_of_measurement: ""
+    volume_night:
+      name: Night Mode Arm/Disarm Volume
+      description: Volume level for the keypad in Armed Night mode
+      default: 0
+      selector:
+        number:
+          min: 0
+          max: 10
+          step: 1
+          unit_of_measurement: ""
 variables:
   alarm: !input alarm
+  volume_night: !input volume_night
+  volume_normal: !input volume_normal
 mode: parallel
 max: 10
 trace:
@@ -115,7 +137,15 @@ trigger:
     id: alarm_armed_away
   - platform: state
     entity_id: !input alarm
+    to: armed_vacation
+    id: alarm_armed_away
+  - platform: state
+    entity_id: !input alarm
     to: armed_home
+    id: alarm_armed_home
+  - platform: state
+    entity_id: !input alarm
+    to: armed_night
     id: alarm_armed_home
   - platform: state
     entity_id: !input alarm
@@ -138,7 +168,7 @@ action:
             - code_entered
             - keypad_disarm
       sequence:
-        - service: alarmo.disarm
+        - action: alarmo.disarm
           data:
             entity_id: !input alarm
             code: >
@@ -158,7 +188,7 @@ action:
               entity_id: !input alarm
               state: disarmed
       sequence:
-        - service: alarmo.arm
+        - action: alarmo.arm
           data:
             entity_id: !input alarm
             mode: '{{ trigger.id.split("_")[2] }}'
@@ -177,7 +207,7 @@ action:
                 event_data: null
           timeout: '5'
           continue_on_timeout: false
-        - service: alarmo.arm
+        - action: alarmo.arm
           data:
             entity_id: !input alarm
             mode: '{{ trigger.id.split("_")[2] }}'
@@ -191,7 +221,7 @@ action:
           id:
             - invalid_code
       sequence:
-        - service: zwave_js.set_value
+        - action: zwave_js.set_value
           target:
             device_id: !input keypad
           data:
@@ -204,7 +234,7 @@ action:
         - condition: trigger
           id: need_bypass
       sequence:
-        - service: zwave_js.set_value
+        - action: zwave_js.set_value
           target:
             device_id: !input keypad
           data:
@@ -217,7 +247,14 @@ action:
         - condition: trigger
           id: alarm_disarmed
       sequence:
-        - service: zwave_js.set_value
+        - action: zwave_js.set_config_parameter
+          target:
+            device_id: !input keypad
+          data:
+            endpoint: "0"
+            parameter: "4"
+            value: "{{ volume_normal if trigger.from_state.state != 'armed_night' else volume_night }}"
+        - action: zwave_js.set_value
           target:
             device_id: !input keypad
           data:
@@ -226,11 +263,18 @@ action:
             property: "2"
             property_key: "1"
             value: 99
+        - action: zwave_js.set_config_parameter
+          target:
+            device_id: !input keypad
+          data:
+            endpoint: "0"
+            parameter: "4"
+            value: "{{ volume_normal }}"
     - conditions:
         - condition: trigger
           id: alarm_armed_away
       sequence:
-        - service: zwave_js.set_value
+        - action: zwave_js.set_value
           target:
             device_id: !input keypad
           data:
@@ -243,7 +287,14 @@ action:
         - condition: trigger
           id: alarm_armed_home
       sequence:
-        - service: zwave_js.set_value
+        - action: zwave_js.set_config_parameter
+          target:
+            device_id: !input keypad
+          data:
+            endpoint: "0"
+            parameter: "4"
+            value: "{{ volume_normal if trigger.to_state.state != 'armed_night' else volume_night }}"
+        - action: zwave_js.set_value
           target:
             device_id: !input keypad
           data:
@@ -251,12 +302,19 @@ action:
             endpoint: "0"
             property: "10"
             property_key: "1"
-            value: 99
+            value: 100
+        - action: zwave_js.set_config_parameter
+          target:
+            device_id: !input keypad
+          data:
+            endpoint: "0"
+            parameter: "4"
+            value: "{{ volume_normal }}"
     - conditions:
         - condition: trigger
           id: alarm_arming
       sequence:
-        - service: zwave_js.set_value
+        - action: zwave_js.set_value
           target:
             device_id: !input keypad
           data:
@@ -269,7 +327,7 @@ action:
         - condition: trigger
           id: alarm_pending
       sequence:
-        - service: zwave_js.set_value
+        - action: zwave_js.set_value
           target:
             device_id: !input keypad
           data:
@@ -282,7 +340,7 @@ action:
         - condition: trigger
           id: alarm_triggered
       sequence:
-        - service: zwave_js.set_value
+        - action: zwave_js.set_value
           target:
             device_id: !input keypad
           data:


### PR DESCRIPTION
Hello, 

First of all, thank you for this excellent blueprint!

I wanted to share my use case, as I'm among those who use the Night Alarm feature. In my setup, the alarm is automatically armed and disarmed based on time and specific conditions. I’ve reviewed #29 and #28, and in my case, I prefer having a distinct "night" mode. This is because the keypad is close to the bedrooms, and I don’t want it announcing "Home and armed" or "Disarmed" while my children are asleep. However, I still appreciate the visual indicator (red icon) to remind me the alarm is active when I open the door late at night.

Here's how I've adjusted the automation to fit my needs:
- Added two new input fields for configuring separate volume levels depending on the current alarm mode (night vs normal).
- Created two new triggers: `armed_night` and `armed_vacation`, which are mapped to the existing handlers (`armed_home` and `armed_away`) to keep the logic simple and avoid over-complication.
- Modified the `armed_home` and `disarm` handlers to adjust the volume based on normal or night modes.

**Note**: Since Home Assistant is transitioning from "service" to "action" syntax, I've refactored the automation to align with this update.

Don't hesitate to try it and give some feedback! 😊
[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Folibos%2FHomeAssistantNotes%2Fblob%2Ffeature%2Fadd-night-mode%2Fkeypad_blueprint.yaml)