### PR TITLE
Fix arming and pending delay

### DIFF
--- a/keypad_blueprint.yaml
+++ b/keypad_blueprint.yaml
@@ -37,6 +37,12 @@ blueprint:
         action:
 variables:
   alarm: !input alarm
+  formatted_delay: >
+    {% set delay = state_attr(alarm, 'delay') %}
+    {% set total_seconds = delay if delay is not none else 0 %}
+    {% set minutes = total_seconds // 60 %}
+    {% set seconds = total_seconds % 60 %}
+    {{ minutes }}m{{ seconds }}s
 mode: parallel
 max: 10
 trace:
@@ -263,8 +269,8 @@ action:
             command_class: "135"
             endpoint: "0"
             property: "18"
-            property_key: "7"
-            value: "{{ state_attr(alarm, 'delay') }}"
+            property_key: "timeout"
+            value: "{{ formatted_delay }}"
     - conditions:
         - condition: trigger
           id: alarm_pending
@@ -276,8 +282,8 @@ action:
             command_class: "135"
             endpoint: "0"
             property: "17"
-            property_key: "7"
-            value: "{{ state_attr(alarm, 'delay') }}"
+            property_key: "timeout"
+            value: "{{ formatted_delay }}"
     - conditions:
         - condition: trigger
           id: alarm_triggered


### PR DESCRIPTION
In the recent ZwaveJS 15.10, there was a [rework](https://github.com/zwave-js/zwave-js/pull/7980) to the indicator values, which causes the blueprint to fail on property_key `7` (delay).

Alarmo provides the delay in seconds so I'm formatting it to `#m#s` to match ZwaveJS's [indicator CC](https://github.com/zwave-js/zwave-js/blob/481069a1194e02fbe2271f7e99a86192d02a5b2f/packages/cc/src/cc/IndicatorCC.ts#L609).

For those who wants the fix now, you'll have to import and replace with my copy:

https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fjsnallen%2FHomeAssistantNotes%2Fblob%2Fmain%2Fkeypad_blueprint.yaml