### PR TITLE
Add multi-keypad Ring Keypad V2 to Alarmo sync blueprint

### DIFF
--- a/RingKeypadV2.md
+++ b/RingKeypadV2.md
@@ -142,3 +142,16 @@ The following tables summarize the indicators by `property`s that actually do an
 I've created a [blueprint](https://github.com/ImSorryButWho/HomeAssistantNotes/blob/main/keypad_blueprint.yaml) that will create an automation which handles all the basic interactions between an `alarm_control_panel` instance and the Ring Keypad v2.  Pair the keypad following the instructions above, and configure an Alarmo instance in your Home Assistant.  Then, you can install the Blueprint above and create the automation, giving it the device for the keypad, the entity_id for the alarm instance, as well as the Z-Wave Node ID for the keypad (necessary to identify the events of interest), and the entry and exit delay times for the alarm.
 
 Please feel free to send pull requests for improvements.  This is my first Blueprint.
+
+## Multi-Keypad Blueprint (Sync Ring Keypad(s) to Alarmo)
+
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2FImSorryButWho%2FHomeAssistantNotes%2Fblob%2Fmain%2Fsync_ring_keypads_to_alarmo.yaml)
+
+If you have more than one Ring Keypad V2, [`sync_ring_keypads_to_alarmo.yaml`](https://github.com/ImSorryButWho/HomeAssistantNotes/blob/main/sync_ring_keypads_to_alarmo.yaml) is a drop-in alternative to `keypad_blueprint.yaml` that services every selected keypad from a single automation. Improvements over the original blueprint:
+
+- **Multi-keypad input** — the `keypads` selector uses `multiple: true`, so you can pick any number of paired Ring Keypads instead of duplicating the automation per device.
+- **Per-keypad failure feedback** — `invalid_code` and `open_sensors` buzz only the keypad that initiated the arm, not every keypad. This is done with an inline `wait_for_trigger` inside the arm branch that listens for success, invalid PIN, or open-sensors in parallel, and routes feedback using a `source_keypad` variable captured from the trigger.
+- **Entity-scoped failure filter** — the `alarmo_failed_to_arm` waits include `entity_id: !input alarm`, so installs with more than one Alarmo panel don't cross-trigger feedback (equivalent to [PR #43](https://github.com/ImSorryButWho/HomeAssistantNotes/pull/43)).
+- **Native unknown-state filter** — uses `not_from: unknown` on the state triggers instead of a top-level template condition, so restart/reload noise is filtered at the trigger layer.
+
+Pair your keypads following the instructions above, then import the blueprint and create one automation that targets all of them.

--- a/sync_ring_keypads_to_alarmo.yaml
+++ b/sync_ring_keypads_to_alarmo.yaml
@@ -1,0 +1,351 @@
+blueprint:
+  name: Sync Ring Keypad(s) to Alarmo
+  description: |
+    🔐 Keeps one or more Ring Keypad V2 devices in sync with Alarmo.
+
+    **Features**
+    - 🔑 Arm / disarm from any keypad controls Alarmo
+    - 💡 Alarmo state drives LEDs and tones on every keypad
+    - 🎯 Invalid PIN or open sensors buzz only the originating keypad
+    - 🚨 Optional Fire / Police / Medical panic button actions
+
+    🔗 Based on [ImSorryButWho's keypad_blueprint.yaml](https://github.com/ImSorryButWho/HomeAssistantNotes).
+  domain: automation
+  input:
+    keypads:
+      name: Ring Keypads
+      description: One or more Ring Keypad V2 devices to sync with Alarmo.
+      selector:
+        device:
+          manufacturer: Ring
+          integration: zwave_js
+          multiple: true
+    alarm:
+      name: Alarm Control Panel entity
+      description: The Alarmo alarm_control_panel entity to synchronize with.
+      selector:
+        entity:
+          domain: alarm_control_panel
+          integration: alarmo
+    selected_action_police:
+      name: Selected Action Police
+      description: Action to run when the Police button is pressed (hold to trigger).
+      default: []
+      selector:
+        action:
+    selected_action_fire:
+      name: Selected Action Fire
+      description: Action to run when the Fire button is pressed (hold to trigger).
+      default: []
+      selector:
+        action:
+    selected_action_medical:
+      name: Selected Action Medical
+      description: Action to run when the Medical button is pressed (hold to trigger).
+      default: []
+      selector:
+        action:
+
+mode: parallel
+max: 10
+
+variables:
+  keypads: !input keypads
+  alarm: !input alarm
+  formatted_delay: >
+    {% set delay = state_attr(alarm, 'delay') %}
+    {% set total_seconds = delay if delay is not none else 0 %}
+    {% set minutes = total_seconds // 60 %}
+    {% set seconds = total_seconds % 60 %}
+    {{ minutes }}m{{ seconds }}s
+
+trigger:
+  # Keypad button events — no device filter here; branches filter via
+  # `trigger.event.data.device_id in keypads` so a single automation can
+  # service any number of selected keypads.
+  - platform: event
+    event_type: zwave_js_notification
+    event_data:
+      command_class: 111
+      event_type: 2
+    id: code_entered
+  - platform: event
+    event_type: zwave_js_notification
+    event_data:
+      command_class: 111
+      event_type: 3
+    id: keypad_disarm
+  - platform: event
+    event_type: zwave_js_notification
+    event_data:
+      command_class: 111
+      event_type: 5
+    id: keypad_arm_away
+  - platform: event
+    event_type: zwave_js_notification
+    event_data:
+      command_class: 111
+      event_type: 6
+    id: keypad_arm_home
+  - platform: event
+    event_type: zwave_js_notification
+    event_data:
+      command_class: 111
+      event_type: 16
+    id: keypad_fire
+  - platform: event
+    event_type: zwave_js_notification
+    event_data:
+      command_class: 111
+      event_type: 17
+    id: keypad_police
+  - platform: event
+    event_type: zwave_js_notification
+    event_data:
+      command_class: 111
+      event_type: 19
+    id: keypad_medical
+
+  # Alarmo state transitions — feedback is broadcast to all keypads.
+  - platform: state
+    entity_id: !input alarm
+    to: disarmed
+    not_from: unknown
+    id: alarm_disarmed
+  - platform: state
+    entity_id: !input alarm
+    to: arming
+    not_from: unknown
+    id: alarm_arming
+  - platform: state
+    entity_id: !input alarm
+    to: armed_away
+    not_from: unknown
+    id: alarm_armed_away
+  - platform: state
+    entity_id: !input alarm
+    to: armed_home
+    not_from: unknown
+    id: alarm_armed_home
+  - platform: state
+    entity_id: !input alarm
+    to: pending
+    not_from: unknown
+    id: alarm_pending
+  - platform: state
+    entity_id: !input alarm
+    to: triggered
+    not_from: unknown
+    id: alarm_triggered
+
+action:
+  choose:
+    # ─── Disarm ────────────────────────────────────────────────
+    - conditions:
+        - condition: trigger
+          id:
+            - code_entered
+            - keypad_disarm
+        - condition: template
+          value_template: "{{ trigger.event.data.device_id in keypads }}"
+      sequence:
+        - service: alarmo.disarm
+          data:
+            entity_id: !input alarm
+            code: >
+              {% if trigger.event.data.event_data != none %}
+                {{ trigger.event.data.event_data }}
+              {% endif %}
+
+    # ─── Arm (with inline per-keypad failure feedback) ─────────
+    - conditions:
+        - condition: trigger
+          id:
+            - keypad_arm_away
+            - keypad_arm_home
+        - condition: template
+          value_template: "{{ trigger.event.data.device_id in keypads }}"
+        - condition: state
+          entity_id: !input alarm
+          state: disarmed
+      sequence:
+        - variables:
+            source_keypad: "{{ trigger.event.data.device_id }}"
+            arm_mode: "{{ trigger.id.split('_')[2] }}"
+            arm_code: >
+              {% if trigger.event.data.event_data != none %}
+                {{ trigger.event.data.event_data }}
+              {% endif %}
+        - service: alarmo.arm
+          data:
+            entity_id: !input alarm
+            mode: "{{ arm_mode }}"
+            force: false
+            code: "{{ arm_code }}"
+        # Wait up to 5s for one of three outcomes — success, invalid PIN,
+        # or open sensors. Only the source keypad gets failure feedback.
+        - wait_for_trigger:
+            - platform: event
+              event_type: zwave_js_notification
+              event_data:
+                command_class: 111
+                event_type: 2
+                event_data: null
+              id: arm_success
+            - platform: event
+              event_type: alarmo_failed_to_arm
+              event_data:
+                entity_id: !input alarm
+                reason: invalid_code
+              id: arm_invalid_code
+            - platform: event
+              event_type: alarmo_failed_to_arm
+              event_data:
+                entity_id: !input alarm
+                reason: open_sensors
+              id: arm_open_sensors
+          timeout: 5
+          continue_on_timeout: true
+        - choose:
+            - conditions: "{{ wait.trigger is not none and wait.trigger.id == 'arm_success' }}"
+              sequence:
+                - service: alarmo.arm
+                  data:
+                    entity_id: !input alarm
+                    mode: "{{ arm_mode }}"
+                    force: true
+                    code: "{{ arm_code }}"
+            - conditions: "{{ wait.trigger is not none and wait.trigger.id == 'arm_invalid_code' }}"
+              sequence:
+                - service: zwave_js.set_value
+                  target:
+                    device_id: "{{ source_keypad }}"
+                  data:
+                    command_class: "135"
+                    endpoint: "0"
+                    property: "9"
+                    property_key: "1"
+                    value: 99
+            - conditions: "{{ wait.trigger is not none and wait.trigger.id == 'arm_open_sensors' }}"
+              sequence:
+                - service: zwave_js.set_value
+                  target:
+                    device_id: "{{ source_keypad }}"
+                  data:
+                    command_class: "135"
+                    endpoint: "0"
+                    property: "16"
+                    property_key: "1"
+                    value: 99
+
+    # ─── State feedback broadcast to all keypads ───────────────
+    - conditions:
+        - condition: trigger
+          id: alarm_disarmed
+      sequence:
+        - repeat:
+            for_each: "{{ keypads }}"
+            sequence:
+              - service: zwave_js.set_value
+                target:
+                  device_id: "{{ repeat.item }}"
+                data:
+                  command_class: "135"
+                  endpoint: "0"
+                  property: "2"
+                  property_key: "1"
+                  value: 99
+    - conditions:
+        - condition: trigger
+          id: alarm_armed_away
+      sequence:
+        - repeat:
+            for_each: "{{ keypads }}"
+            sequence:
+              - service: zwave_js.set_value
+                target:
+                  device_id: "{{ repeat.item }}"
+                data:
+                  command_class: "135"
+                  endpoint: "0"
+                  property: "11"
+                  property_key: "1"
+                  value: 99
+    - conditions:
+        - condition: trigger
+          id: alarm_armed_home
+      sequence:
+        - repeat:
+            for_each: "{{ keypads }}"
+            sequence:
+              - service: zwave_js.set_value
+                target:
+                  device_id: "{{ repeat.item }}"
+                data:
+                  command_class: "135"
+                  endpoint: "0"
+                  property: "10"
+                  property_key: "1"
+                  value: 99
+    - conditions:
+        - condition: trigger
+          id: alarm_arming
+      sequence:
+        - repeat:
+            for_each: "{{ keypads }}"
+            sequence:
+              - service: zwave_js.set_value
+                target:
+                  device_id: "{{ repeat.item }}"
+                data:
+                  command_class: "135"
+                  endpoint: "0"
+                  property: "18"
+                  property_key: "timeout"
+                  value: "{{ formatted_delay }}"
+    - conditions:
+        - condition: trigger
+          id: alarm_pending
+      sequence:
+        - repeat:
+            for_each: "{{ keypads }}"
+            sequence:
+              - service: zwave_js.set_value
+                target:
+                  device_id: "{{ repeat.item }}"
+                data:
+                  command_class: "135"
+                  endpoint: "0"
+                  property: "17"
+                  property_key: "timeout"
+                  value: "{{ formatted_delay }}"
+    - conditions:
+        - condition: trigger
+          id: alarm_triggered
+      sequence:
+        - repeat:
+            for_each: "{{ keypads }}"
+            sequence:
+              - service: zwave_js.set_value
+                target:
+                  device_id: "{{ repeat.item }}"
+                data:
+                  command_class: "135"
+                  endpoint: "0"
+                  property: "13"
+                  property_key: "9"
+                  value: 99
+
+    # ─── Panic buttons — user-defined actions ──────────────────
+    - conditions:
+        - condition: trigger
+          id: keypad_fire
+      sequence: !input selected_action_fire
+    - conditions:
+        - condition: trigger
+          id: keypad_police
+      sequence: !input selected_action_police
+    - conditions:
+        - condition: trigger
+          id: keypad_medical
+      sequence: !input selected_action_medical


### PR DESCRIPTION
## Summary

Adds `sync_ring_keypads_to_alarmo.yaml`, an additive sibling to `keypad_blueprint.yaml` that lets one automation service every paired Ring Keypad V2. The existing single-keypad blueprint is untouched, so this is an opt-in alternative for installs with more than one keypad.

## Motivation

Running one automation per keypad gets noisy fast: invalid-PIN feedback and "open sensors" buzzes fire on every keypad, not just the one being used. This blueprint targets that and a couple of other smaller papercuts.

## Behavioral improvements over `keypad_blueprint.yaml`

- **Multi-keypad input** - the `keypads` selector uses `multiple: true`, so you select any number of paired keypads instead of duplicating the automation.
- **Per-keypad failure feedback** - inline `wait_for_trigger` inside the arm branch listens for success / invalid PIN / open sensors in parallel and routes the buzz only to the keypad that initiated the arm (captured into a `source_keypad` variable).
- **Entity-scoped failure filter** - `alarmo_failed_to_arm` event waits include `entity_id: !input alarm`, so installs with more than one Alarmo panel don't cross-trigger feedback. This is equivalent to the fix in #43.
- **Native unknown-state filter** - state triggers use `not_from: unknown` directly instead of relying on a top-level template condition, so restart/reload noise is filtered at the trigger layer.

## Docs

`RingKeypadV2.md` gets a new section after the existing Automation Blueprint section, with an HA import badge pointing at this file and a short rationale.

## Testing

Running on two paired keypads (front door + back door) wired to a single Alarmo instance for about three weeks with zero issues - arm/disarm flows, invalid PIN, open-sensor buzzes, and the cancel-during-pending paths all isolate to the originating keypad as intended.